### PR TITLE
Fixed @ Command Injection in moment-timezone

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,10 +1403,10 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-moment-timezone@^0.5.34:
-  version "0.5.34"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
-  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+moment-timezone@^0.5.35:
+  version "0.5.35"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.35.tgz#6fa2631bdbe8ff04f6b8753f7199516be6dc9839"
+  integrity sha512-cY/pBOEXepQvlgli06ttCTKcIf8cD1nmNwOKQQAdHBqYApQSpAqotBMX0RJZNgMp6i0PlZuf1mFtnlyEkwyvFw==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
## Vulnerability Description
**Command Injection via grunt-zdownload.js and MITM on iana's ftp endpoint**
The `tasks/data-download.js` script takes in a parameter from grunt and uses it to form a command line which is then executed:
```
6  module.exports = function (grunt) {
7      grunt.registerTask('data-download', '1. Download data from iana.org/time-zones.', function (version) {
8          version = version || 'latest';

10          var done  = this.async(),
11              src   = 'ftp://ftp.iana.org/tz/tzdata-latest.tar.gz',
12              curl  = path.resolve('temp/curl', version, 'data.tar.gz'),
13              dest  = path.resolve('temp/download', version);
...
24          exec('curl ' + src + ' -o ' + curl + ' && cd ' + dest + ' && gzip -dc ' + curl + ' | tar -xf -', function (err) {
```
Ordinarily, one one run this script using something like `grunt data-download:2014d`, in which case version would have the value `2014d`. However, if an attacker were to provide additional content on the command line, they would be able to execute arbitrary code
```
root@e94ba0490b65:/usr/src/app/moment-timezone# grunt 'data-download:2014d ; echo flag>/tmp/foo #'
\Running "data-download:2014d ; echo flag>/tmp/foo #" (data-download) task
>> Downloading https://data.iana.org/time-zones/releases/tzdata2014d ; echo flag>/tmp/foo #.tar.gz
>> Downloaded https://data.iana.org/time-zones/releases/tzdata2014d ; echo flag>/tmp/foo #.tar.gz

Done.
root@e94ba0490b65:/usr/src/app/moment-timezone# cat /tmp/foo
flag
```
**Command Injection via data-zdump.js**
The `tasks/data-zdump.js` script reads a list of files present in a temporary directory (created by previous tasks), and for each one, assembles and executes a command line without sanitization. As a result, an attacker able to influence the contents of that directory could gain code execution. This attack is exacerbated by timezone data being downloaded via cleartext FTP (described above), but beyond that, an attacker at iana.org able to modify the timezone files could disrupt any systems that build moment-timezone.
```
15              files     = grunt.file.expand({ filter : 'isFile', cwd : 'temp/zic/' + version }, '**/*');
...
27          function next () {
...
33              var file = files.pop(),
34                  src  = path.join(zicBase, file),
35                  dest = path.join(zdumpBase, file);
36              exec('zdump -v ' + src, { maxBuffer: 20*1024*1024 }, function (err, stdout) {
```
In this case, an attacker able to add a file to `temp/zic/2014d` (for example) with a filename like `Z; curl www.redacted` would influence the called to exec on line 36 and run arbitrary code. There are a few minor challenges in exploiting this, since the string needs to be a valid filename.

**Command Injection via data-zic.js**
Similar to the vulnerability in /tasks/data-download.js, the /tasks/data-zic.js script takes a version from the command line and uses it as part of a command line, executed without sanitization.
```
10          var done  = this.async(),
11              dest  = path.resolve('temp/zic', version),
...
22              var file = files.shift(),
23                  src = path.resolve('temp/download', version, file);
24
25              exec('zic -d ' + dest + ' ' + src, function (err) {
```
As a result, an attacker able to influence that string can run arbitrary commands. Of course, it requires an attacker able to influence the command passed to grunt, so may be unlikely in practice.
```
root@e94ba0490b65:/usr/src/app/moment-timezone# grunt 'data-zic:2014d; echo hi > /tmp/evil; echo '
Running "data-zic:2014d; echo hi > /tmp/evil; echo " (data-zic) task
exec: zid -d /usr/src/app/moment-timezone/temp/zic/2014d; echo hi > /tmp/evil; echo  /usr/src/app/moment-timezone/temp/download/2014d; echo hi > /tmp/evil; echo /africa
...

root@e94ba0490b65:/usr/src/app/moment-timezone# cat /tmp/evil
hi
```
Patches References
The supplied patch on top of 0.5.34 is applicable with minor tweaks to all affected versions. It switches `exec` to `execFile` so arbitrary bash fragments won't be executed any more.
 * https://knowledge-base.secureflag.com/vulnerabilities/code_injection/os_command_injection_nodejs.html
 * https://auth0.com/blog/preventing-command-injection-attacks-in-node-js-apps/